### PR TITLE
Add functions to allow users to import Svg's from bytes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added a `from_bytes` function on the `Svg` struct that loads in an SVG from byte data
+- Added a `tesselate` function on the `Svg` struct that calculates the bevy mesh.
 
 ## [0.10.0] - 2023-04-10
 ### Changed

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -18,7 +18,7 @@ impl AssetLoader for SvgAssetLoader {
     ) -> BoxedFuture<'a, Result<(), anyhow::Error>> {
         Box::pin(async move {
             debug!("Parsing SVG: {} ...", load_context.path().display());
-            let mut svg = Svg::from_bytes(bytes, load_context.path())?;
+            let mut svg = Svg::from_bytes(bytes, load_context.path(), None::<&std::path::Path>)?;
             let name = &load_context
                 .path()
                 .file_name()

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -29,11 +29,7 @@ use bevy::{
     sprite::Mesh2dHandle,
 };
 
-use crate::{
-    loader::SvgAssetLoader,
-    origin, render,
-    svg::Svg,
-};
+use crate::{loader::SvgAssetLoader, origin, render, svg::Svg};
 
 /// Stages for this plugin.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
@@ -50,18 +46,10 @@ impl Plugin for SvgPlugin {
     fn build(&self, app: &mut App) {
         app.add_asset::<Svg>()
             .init_asset_loader::<SvgAssetLoader>()
-            .configure_set(
-                Stage::SVG.after(CoreSet::PostUpdate)
-            )
-            .add_system(
-                svg_mesh_linker.in_base_set(Stage::SVG)
-            )
-            .add_system(
-                origin::add_origin_state.in_base_set(Stage::SVG)
-            )
-            .add_system(
-                origin::apply_origin.in_base_set(CoreSet::PostUpdate)
-            )
+            .configure_set(Stage::SVG.after(CoreSet::PostUpdate))
+            .add_system(svg_mesh_linker.in_base_set(Stage::SVG))
+            .add_system(origin::add_origin_state.in_base_set(Stage::SVG))
+            .add_system(origin::apply_origin.in_base_set(CoreSet::PostUpdate))
             .add_plugin(render::SvgPlugin);
     }
 }

--- a/src/render/plugin.rs
+++ b/src/render/plugin.rs
@@ -1,4 +1,7 @@
-use crate::{resources::{FillTessellator, StrokeTessellator}, prelude::Svg};
+use crate::{
+    prelude::Svg,
+    resources::{FillTessellator, StrokeTessellator},
+};
 use bevy::{
     app::{App, Plugin},
     asset::{Assets, Handle},

--- a/src/render/svg2d/plugin.rs
+++ b/src/render/svg2d/plugin.rs
@@ -1,23 +1,18 @@
 use bevy::{
     app::{App, Plugin},
-    asset::{AddAsset, load_internal_asset},
+    asset::{load_internal_asset, AddAsset},
     render::render_resource::{Shader, ShaderRef},
     sprite::{Material2d, Material2dPlugin},
 };
 
-use crate::{render::svg2d::{SVG_2D_SHADER_HANDLE}, svg::Svg};
+use crate::{render::svg2d::SVG_2D_SHADER_HANDLE, svg::Svg};
 
 /// Plugin that renders [`Svg`](crate::svg::Svg)s in 2D
 pub struct RenderPlugin;
 
 impl Plugin for RenderPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            SVG_2D_SHADER_HANDLE,
-            "svg_2d.wgsl",
-            Shader::from_wgsl
-        );
+        load_internal_asset!(app, SVG_2D_SHADER_HANDLE, "svg_2d.wgsl", Shader::from_wgsl);
 
         app.add_plugin(Material2dPlugin::<Svg>::default())
             .register_asset_reflect::<Svg>();

--- a/src/render/svg3d/plugin.rs
+++ b/src/render/svg3d/plugin.rs
@@ -1,6 +1,6 @@
 use bevy::{
     app::{App, Plugin},
-    asset::{AddAsset, load_internal_asset},
+    asset::{load_internal_asset, AddAsset},
     pbr::{Material, MaterialPlugin},
     render::render_resource::{Shader, ShaderRef},
 };
@@ -14,12 +14,7 @@ pub struct RenderPlugin;
 
 impl Plugin for RenderPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            SVG_3D_SHADER_HANDLE,
-            "svg_3d.wgsl",
-            Shader::from_wgsl
-        );
+        load_internal_asset!(app, SVG_3D_SHADER_HANDLE, "svg_3d.wgsl", Shader::from_wgsl);
 
         app.add_plugin(MaterialPlugin::<Svg>::default())
             .register_asset_reflect::<Svg>();

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::PathBuf;
 
 use bevy::{
     asset::Handle,
@@ -53,15 +53,20 @@ impl Default for Svg {
 
 impl Svg {
     /// Loads an SVG from bytes
-    pub fn from_bytes(bytes: &[u8], path: &Path) -> Result<Svg, FileSvgError> {
+    pub fn from_bytes(
+        bytes: &[u8],
+        path: impl Into<PathBuf>,
+        fonts: Option<impl Into<PathBuf>>,
+    ) -> Result<Svg, FileSvgError> {
         let mut opts = usvg::Options::default();
         opts.fontdb.load_system_fonts();
-        opts.fontdb.load_fonts_dir("./assets");
+        opts.fontdb
+            .load_fonts_dir(fonts.map(|p| p.into()).unwrap_or("./assets".into()));
 
         let svg_tree =
             usvg::Tree::from_data(&bytes, &opts.to_ref()).map_err(|err| FileSvgError {
                 error: err.into(),
-                path: format!("{}", path.display()),
+                path: format!("{}", path.into().display()),
             })?;
 
         Ok(Svg::from_tree(svg_tree))


### PR DESCRIPTION
### Motivation
Allow users to load in SVG's during the build process. Example:
```rust
pub struct IconsPlugin;
impl Plugin for IconsPlugin {
    fn build(&self, app: &mut bevy::prelude::App) {
        let expand_less_bytes = include_bytes!("expand_less.svg");
        let expand_more_bytes = include_bytes!("expand_more.svg");
        let mut expand_less = Svg::from_bytes(expand_less_bytes, &Path::new("")).unwrap();
        let mut expand_more = Svg::from_bytes(expand_more_bytes, &Path::new("")).unwrap();

        let mut meshes = app.world.get_resource_mut::<Assets<Mesh>>().unwrap();
        expand_less.mesh = meshes.add(expand_less.tessellate());
        expand_more.mesh = meshes.add(expand_more.tessellate());

        let mut svgs = app.world.get_resource_mut::<Assets<Svg>>().unwrap();
        svgs.set_untracked(EXPAND_LESS_HANDLE, expand_less);
        svgs.set_untracked(EXPAND_MORE_HANDLE, expand_more);
    }
}
```