### PR TITLE
Use feature flags more consistently to drop unnecessary dependancies and systems

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,9 @@
 )]
 
 mod loader;
+#[cfg(any(feature = "2d", feature = "3d"))]
 mod origin;
+#[cfg(any(feature = "2d", feature = "3d"))]
 mod plugin;
 mod render;
 mod resources;
@@ -35,14 +37,35 @@ mod svg;
 
 /// Import this module as `use bevy_svg::prelude::*` to get convenient imports.
 pub mod prelude {
+    #[cfg(any(feature = "2d", feature = "3d"))]
+    pub use crate::origin::Origin;
+    #[cfg(any(feature = "2d", feature = "3d"))]
+    use crate::plugin::SvgRenderPlugin;
     #[cfg(feature = "2d")]
     pub use crate::render::Svg2dBundle;
     #[cfg(feature = "3d")]
     pub use crate::render::Svg3dBundle;
-    pub use crate::{origin::Origin, plugin::SvgPlugin, svg::Svg};
+    pub use crate::svg::Svg;
     pub use lyon_tessellation::{
         FillOptions, FillRule, LineCap, LineJoin, Orientation, StrokeOptions,
     };
+
+    use crate::loader::SvgAssetLoader;
+    use bevy::{
+        app::{App, Plugin},
+        asset::AddAsset,
+    };
+
+    /// A plugin that provides resources and a system to draw [`Svg`]s.
+    pub struct SvgPlugin;
+
+    impl Plugin for SvgPlugin {
+        fn build(&self, app: &mut App) {
+            app.add_asset::<Svg>().init_asset_loader::<SvgAssetLoader>();
+            #[cfg(any(feature = "2d", feature = "3d"))]
+            app.add_plugin(SvgRenderPlugin);
+        }
+    }
 }
 
 /// A locally defined [`std::convert::Into`] surrogate to overcome orphan rules.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,9 @@ mod svg;
 
 /// Import this module as `use bevy_svg::prelude::*` to get convenient imports.
 pub mod prelude {
+    pub use super::SvgPlugin;
     #[cfg(any(feature = "2d", feature = "3d"))]
     pub use crate::origin::Origin;
-    #[cfg(any(feature = "2d", feature = "3d"))]
-    use crate::plugin::SvgRenderPlugin;
     #[cfg(feature = "2d")]
     pub use crate::render::Svg2dBundle;
     #[cfg(feature = "3d")]
@@ -49,22 +48,24 @@ pub mod prelude {
     pub use lyon_tessellation::{
         FillOptions, FillRule, LineCap, LineJoin, Orientation, StrokeOptions,
     };
+}
 
-    use crate::loader::SvgAssetLoader;
-    use bevy::{
-        app::{App, Plugin},
-        asset::AddAsset,
-    };
+#[cfg(any(feature = "2d", feature = "3d"))]
+use crate::plugin::SvgRenderPlugin;
+use crate::{loader::SvgAssetLoader, svg::Svg};
+use bevy::{
+    app::{App, Plugin},
+    asset::AddAsset,
+};
 
-    /// A plugin that provides resources and a system to draw [`Svg`]s.
-    pub struct SvgPlugin;
+/// A plugin that provides resources and a system to draw [`Svg`]s.
+pub struct SvgPlugin;
 
-    impl Plugin for SvgPlugin {
-        fn build(&self, app: &mut App) {
-            app.add_asset::<Svg>().init_asset_loader::<SvgAssetLoader>();
-            #[cfg(any(feature = "2d", feature = "3d"))]
-            app.add_plugin(SvgRenderPlugin);
-        }
+impl Plugin for SvgPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_asset::<Svg>().init_asset_loader::<SvgAssetLoader>();
+        #[cfg(any(feature = "2d", feature = "3d"))]
+        app.add_plugin(SvgRenderPlugin);
     }
 }
 


### PR DESCRIPTION
Some changes to better respect the feature flags, as well as better support for having neither 2d nor 3d enabled, which makes the plugin just provide assets and requires the user to render the svgs theirselves. This change fixes an issue where bevy_sprite can be disabled but even if the 2d feature is disabled this crate fails to compile.

I'm not too happy about how the changes affect readability, so if you have any ideas on how this could be better structured please let me know.