### PR TITLE
Bump Bevy to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = ["2d", "3d"]
 3d = ["bevy/bevy_pbr"]
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = ["bevy_asset", "bevy_core_pipeline", "bevy_render"] }
+bevy = { version = "0.15", default-features = false, features = ["bevy_asset", "bevy_core_pipeline", "bevy_render"] }
 copyless = "0.1"
 
 lyon_geom = "1.0"
@@ -34,7 +34,7 @@ anyhow = "1.0"
 thiserror = "1.0"
 
 [dev-dependencies]
-bevy = { version = "0.14", default-features = true }
+bevy = { version = "0.15", default-features = true }
 
 #### 2D examples ####
 [[example]]

--- a/examples/2d/complex_one_color.rs
+++ b/examples/2d/complex_one_color.rs
@@ -6,7 +6,6 @@ mod common;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "2d_complex_one_color".to_string(),
@@ -22,14 +21,13 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let svg = asset_server.load("asteroid_field.svg");
-    commands.spawn(Camera2dBundle::default());
-    commands.spawn(Svg2dBundle {
-        svg,
-        origin: Origin::Center,
-        transform: Transform {
+    commands.spawn((Camera2d::default(), Msaa::Sample4));
+    commands.spawn((
+        Svg2d(svg),
+        Origin::Center,
+        Transform {
             scale: Vec3::new(2.0, 2.0, 1.0),
             ..Default::default()
         },
-        ..Default::default()
-    });
+    ));
 }

--- a/examples/2d/multiple_translation.rs
+++ b/examples/2d/multiple_translation.rs
@@ -6,7 +6,6 @@ mod common;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "2d_multiple_translation".to_string(),
@@ -23,30 +22,20 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let svg = asset_server.load("asteroid_field.svg");
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d::default());
     commands.spawn((
-        Svg2dBundle {
-            svg,
-            origin: Origin::Center,
-            transform: Transform {
-                translation: Vec3::new(100.0, 0.0, 0.0),
-                scale: Vec3::new(2.0, 2.0, 1.0),
-                ..Default::default()
-            },
+        Svg2d(svg),
+        Origin::Center,
+        Transform {
+            translation: Vec3::new(100.0, 0.0, 0.0),
+            scale: Vec3::new(2.0, 2.0, 1.0),
             ..Default::default()
         },
         Direction::Up,
     ));
 
     let svg = asset_server.load("neutron_star.svg");
-    commands.spawn((
-        Svg2dBundle {
-            svg,
-            origin: Origin::Center,
-            ..Default::default()
-        },
-        Direction::Up,
-    ));
+    commands.spawn((Svg2d(svg), Origin::Center, Direction::Up));
 }
 
 #[derive(Component)]
@@ -57,12 +46,12 @@ enum Direction {
 
 fn svg_movement(
     time: Res<Time>,
-    mut svg_position: Query<(&mut Direction, &mut Transform), With<Handle<Svg>>>,
+    mut svg_position: Query<(&mut Direction, &mut Transform), With<Svg2d>>,
 ) {
     for (mut direction, mut transform) in &mut svg_position {
         match *direction {
-            Direction::Up => transform.translation.y += 150. * time.delta_seconds(),
-            Direction::Down => transform.translation.y -= 150. * time.delta_seconds(),
+            Direction::Up => transform.translation.y += 150. * time.delta_secs(),
+            Direction::Down => transform.translation.y -= 150. * time.delta_secs(),
         }
 
         if transform.translation.y > 200. {

--- a/examples/2d/origin_check.rs
+++ b/examples/2d/origin_check.rs
@@ -6,7 +6,6 @@ mod common;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "origin_check".to_string(),
@@ -22,18 +21,7 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let svg = asset_server.load("box.svg");
-    commands.spawn(Camera2dBundle::default());
-    commands.spawn(Svg2dBundle {
-        svg: svg.clone(),
-        origin: Origin::Center,
-        ..Default::default()
-    });
-    commands.spawn((
-        Svg2dBundle {
-            svg,
-            origin: Origin::TopLeft,
-            ..Default::default()
-        },
-        common::DontChange,
-    ));
+    commands.spawn(Camera2d::default());
+    commands.spawn((Svg2d(svg.clone()), Origin::Center));
+    commands.spawn((Svg2d(svg), Origin::TopLeft, common::DontChange));
 }

--- a/examples/2d/preloading.rs
+++ b/examples/2d/preloading.rs
@@ -7,7 +7,6 @@ mod common;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "preloading".to_string(),
@@ -23,7 +22,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d::default());
 }
 
 #[derive(Default, Eq, PartialEq)]
@@ -50,11 +49,7 @@ fn run(mut commands: Commands, asset_server: Res<AssetServer>, mut fsm: Local<Tu
             if *frames > 0 {
                 *fsm = TutorialFsm::Wait(handle.clone(), *frames - 1);
             } else if let Some(svg) = asset_server.get_handle("neutron_star.svg") {
-                commands.spawn(Svg2dBundle {
-                    svg,
-                    origin: Origin::Center,
-                    ..Default::default()
-                });
+                commands.spawn((Svg2d(svg), Origin::Center));
 
                 *fsm = TutorialFsm::Loaded;
                 dbg!("We loaded");

--- a/examples/2d/twinkle.rs
+++ b/examples/2d/twinkle.rs
@@ -6,7 +6,6 @@ mod common;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "2d_twinkle".to_string(),
@@ -22,10 +21,6 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let svg = asset_server.load("twinkle.svg");
-    commands.spawn(Camera2dBundle::default());
-    commands.spawn(Svg2dBundle {
-        svg,
-        origin: Origin::Center,
-        ..Default::default()
-    });
+    commands.spawn(Camera2d::default());
+    commands.spawn((Svg2d(svg), Origin::Center));
 }

--- a/examples/2d/two_colors.rs
+++ b/examples/2d/two_colors.rs
@@ -6,7 +6,6 @@ mod common;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "2d_two_colors".to_string(),
@@ -22,10 +21,6 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let svg = asset_server.load("neutron_star.svg");
-    commands.spawn(Camera2dBundle::default());
-    commands.spawn(Svg2dBundle {
-        svg,
-        origin: Origin::Center,
-        ..Default::default()
-    });
+    commands.spawn(Camera2d::default());
+    commands.spawn((Svg2d(svg), Origin::Center));
 }

--- a/examples/3d/complex_one_color.rs
+++ b/examples/3d/complex_one_color.rs
@@ -6,7 +6,6 @@ mod common;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "3d_complex_one_color".to_string(),
@@ -22,15 +21,14 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let svg = asset_server.load("asteroid_field.svg");
-    commands.spawn(Camera3dBundle::default());
-    commands.spawn(Svg3dBundle {
-        svg,
-        origin: Origin::Center,
-        transform: Transform {
+    commands.spawn(Camera3d::default());
+    commands.spawn((
+        Svg3d(svg),
+        Origin::Center,
+        Transform {
             translation: Vec3::new(0.0, 0.0, -600.0),
             scale: Vec3::new(2.0, 2.0, 1.0),
             ..Default::default()
         },
-        ..Default::default()
-    });
+    ));
 }

--- a/examples/3d/multiple_perspective.rs
+++ b/examples/3d/multiple_perspective.rs
@@ -6,7 +6,6 @@ mod common;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "3d_multiple_perspective".to_string(),
@@ -22,39 +21,35 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let svg = asset_server.load("neutron_star.svg");
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(100.0, 175.0, 0.0)
-            .looking_at(Vec3::new(0.0, 0.0, -600.0), Vec3::Y),
-        ..Default::default()
-    });
-    commands.spawn(Svg3dBundle {
-        svg: svg.clone(),
-        origin: Origin::Center,
-        transform: Transform {
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(100.0, 175.0, 0.0).looking_at(Vec3::new(0.0, 0.0, -600.0), Vec3::Y),
+    ));
+    commands.spawn((
+        Svg3d(svg.clone()),
+        Origin::Center,
+        Transform {
             translation: Vec3::new(0.0, 0.0, -600.0),
             rotation: Quat::from_rotation_x(-std::f32::consts::PI * 3.0),
             ..Default::default()
         },
-        ..Default::default()
-    });
-    commands.spawn(Svg3dBundle {
-        svg: svg.clone(),
-        origin: Origin::Center,
-        transform: Transform {
+    ));
+    commands.spawn((
+        Svg3d(svg.clone()),
+        Origin::Center,
+        Transform {
             translation: Vec3::new(0.0, 0.0, -700.0),
             rotation: Quat::from_rotation_x(-std::f32::consts::PI * 3.0),
             ..Default::default()
         },
-        ..Default::default()
-    });
-    commands.spawn(Svg3dBundle {
-        svg,
-        origin: Origin::Center,
-        transform: Transform {
+    ));
+    commands.spawn((
+        Svg3d(svg),
+        Origin::Center,
+        Transform {
             translation: Vec3::new(0.0, 0.0, -800.0),
             rotation: Quat::from_rotation_x(-std::f32::consts::PI * 3.0),
             ..Default::default()
         },
-        ..Default::default()
-    });
+    ));
 }

--- a/examples/3d/multiple_translation.rs
+++ b/examples/3d/multiple_translation.rs
@@ -6,7 +6,6 @@ mod common;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "3d_multiple_translation".to_string(),
@@ -23,16 +22,13 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let svg = asset_server.load("asteroid_field.svg");
-    commands.spawn(Camera3dBundle::default());
+    commands.spawn(Camera3d::default());
     commands.spawn((
-        Svg3dBundle {
-            svg,
-            origin: Origin::Center,
-            transform: Transform {
-                translation: Vec3::new(100.0, 0.0, -600.0),
-                scale: Vec3::new(2.0, 2.0, 1.0),
-                ..Default::default()
-            },
+        Svg3d(svg.clone()),
+        Origin::Center,
+        Transform {
+            translation: Vec3::new(100.0, 0.0, -600.0),
+            scale: Vec3::new(2.0, 2.0, 1.0),
             ..Default::default()
         },
         Direction::Up,
@@ -40,13 +36,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     let svg = asset_server.load("neutron_star.svg");
     commands.spawn((
-        Svg3dBundle {
-            svg,
-            origin: Origin::Center,
-            transform: Transform {
-                translation: Vec3::new(0.0, 0.0, -600.0),
-                ..Default::default()
-            },
+        Svg3d(svg.clone()),
+        Transform {
+            translation: Vec3::new(0.0, 0.0, -600.0),
             ..Default::default()
         },
         Direction::Up,
@@ -61,12 +53,12 @@ enum Direction {
 
 fn svg_movement(
     time: Res<Time>,
-    mut svg_position: Query<(&mut Direction, &mut Transform), With<Handle<Svg>>>,
+    mut svg_position: Query<(&mut Direction, &mut Transform), With<Svg3d>>,
 ) {
     for (mut direction, mut transform) in &mut svg_position {
         match *direction {
-            Direction::Up => transform.translation.y += 150.0 * time.delta_seconds(),
-            Direction::Down => transform.translation.y -= 150.0 * time.delta_seconds(),
+            Direction::Up => transform.translation.y += 150.0 * time.delta_secs(),
+            Direction::Down => transform.translation.y -= 150.0 * time.delta_secs(),
         }
 
         if transform.translation.y > 200.0 {

--- a/examples/3d/origin_check.rs
+++ b/examples/3d/origin_check.rs
@@ -6,7 +6,6 @@ mod common;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "origin_check".to_string(),
@@ -22,24 +21,20 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let svg = asset_server.load("box.svg");
-    commands.spawn(Camera3dBundle::default());
-    commands.spawn(Svg3dBundle {
-        svg: svg.clone(),
-        origin: Origin::Center,
-        transform: Transform {
+    commands.spawn(Camera3d::default());
+    commands.spawn((
+        Svg3d(svg.clone()),
+        Origin::Center,
+        Transform {
             translation: Vec3::new(0.0, 0.0, -600.0),
             ..Default::default()
         },
-        ..Default::default()
-    });
+    ));
     commands.spawn((
-        Svg3dBundle {
-            svg,
-            origin: Origin::TopLeft,
-            transform: Transform {
-                translation: Vec3::new(0.0, 0.0, -600.0),
-                ..Default::default()
-            },
+        Svg3d(svg.clone()),
+        Origin::TopLeft,
+        Transform {
+            translation: Vec3::new(0.0, 0.0, -600.0),
             ..Default::default()
         },
         common::DontChange,

--- a/examples/3d/twinkle.rs
+++ b/examples/3d/twinkle.rs
@@ -6,7 +6,6 @@ mod common;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "3d_twinkle".to_string(),
@@ -22,18 +21,17 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let svg = asset_server.load("twinkle.svg");
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(5.0, 8.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
-    });
-    commands.spawn(Svg3dBundle {
-        svg,
-        origin: Origin::Center,
-        transform: Transform {
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(5.0, 8.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+    commands.spawn((
+        Svg3d(svg.clone()),
+        Origin::Center,
+        Transform {
             translation: Vec3::new(0.0, 0.0, -1.0),
             scale: Vec3::new(0.01, 0.01, 1.0),
             rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
         },
-        ..Default::default()
-    });
+    ));
 }

--- a/examples/3d/two_colors.rs
+++ b/examples/3d/two_colors.rs
@@ -6,7 +6,6 @@ mod common;
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Sample4)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "3d_two_colors".to_string(),
@@ -22,14 +21,13 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let svg = asset_server.load("neutron_star.svg");
-    commands.spawn(Camera3dBundle::default());
-    commands.spawn(Svg3dBundle {
-        svg,
-        origin: Origin::Center,
-        transform: Transform {
+    commands.spawn(Camera3d::default());
+    commands.spawn((
+        Svg3d(svg.clone()),
+        Origin::Center,
+        Transform {
             translation: Vec3::new(0.0, 0.0, -600.0),
             ..Default::default()
         },
-        ..Default::default()
-    });
+    ));
 }

--- a/examples/common/lib.rs
+++ b/examples/common/lib.rs
@@ -1,5 +1,6 @@
 use bevy::color::palettes::css::{GOLD, GREEN};
 use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
+use bevy::text::TextSpanAccess;
 use bevy::{
     diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
     prelude::*,
@@ -34,70 +35,30 @@ fn setup_legend(mut commands: Commands, asset_server: Res<AssetServer>) {
     let font_bold = asset_server.load("fonts/FiraSans-Bold.ttf");
     let font_medium = asset_server.load("fonts/FiraMono-Medium.ttf");
 
-    commands.spawn((Text::from_sections([
-        TextSection::new(
-            "Key Info",
-            TextStyle {
-                font: font_bold.clone(),
-                font_size: 30.0,
-                color: Color::WHITE,
+    commands
+        .spawn((
+            Text::default(),
+            TextColor::WHITE,
+            TextFont::from_font(font_medium).with_font_size(20.0),
+            Node {
+                position_type: PositionType::Absolute,
+                top: Val::Px(5.0),
+                right: Val::Px(15.0),
+                ..default()
             },
-        ),
-        TextSection::new(
-            "\nF",
-            TextStyle {
-                font: font_bold.clone(),
-                font_size: 20.0,
-                color: Color::WHITE,
-            },
-        ),
-        TextSection::new(
-            " - Toggle Frame Diagnostics",
-            TextStyle {
-                font: font_medium.clone(),
-                font_size: 20.0,
-                color: Color::WHITE,
-            },
-        ),
-        TextSection::new(
-            "\nO",
-            TextStyle {
-                font: font_bold.clone(),
-                font_size: 20.0,
-                color: Color::WHITE,
-            },
-        ),
-        TextSection::new(
-            " - Cycle through Origins",
-            TextStyle {
-                font: font_medium.clone(),
-                font_size: 20.0,
-                color: Color::WHITE,
-            },
-        ),
-        TextSection::new(
-            "\nV",
-            TextStyle {
-                font: font_bold.clone(),
-                font_size: 20.0,
-                color: Color::WHITE,
-            },
-        ),
-        TextSection::new(
-            " - Toggle visibility",
-            TextStyle {
-                font: font_medium.clone(),
-                font_size: 20.0,
-                color: Color::WHITE,
-            },
-        ),
-    ])
-    .with_style(Style {
-        position_type: PositionType::Absolute,
-        top: Val::Px(5.0),
-        right: Val::Px(15.0),
-        ..default()
-    }),));
+        ))
+        .with_children(|commands| {
+            commands.spawn((
+                TextSpan::new("Key Info"),
+                TextFont::from_font(font_bold.clone()).with_font_size(30.0),
+            ));
+            commands.spawn((TextSpan::new("\nF"), TextFont::from_font(font_bold.clone())));
+            commands.spawn(TextSpan::new(" - Toggle Frame Diagnostics"));
+            commands.spawn((TextSpan::new("\nO"), TextFont::from_font(font_bold.clone())));
+            commands.spawn(TextSpan::new(" - Cycle through Origins"));
+            commands.spawn((TextSpan::new("\nV"), TextFont::from_font(font_bold.clone())));
+            commands.spawn(TextSpan::new(" - Toggle visibility"));
+        });
 }
 
 #[derive(Component)]
@@ -152,6 +113,15 @@ fn keyboard_input_system(
 #[derive(Component)]
 struct FpsText;
 
+#[derive(Component)]
+struct FpsMinText;
+
+#[derive(Component)]
+struct FpsMaxText;
+
+#[derive(Component)]
+struct FrameTimeText;
+
 #[derive(Resource)]
 struct FpsValues {
     min: f64,
@@ -171,98 +141,82 @@ fn setup_fps_counter(mut commands: Commands, asset_server: Res<AssetServer>) {
     let font_bold = asset_server.load("fonts/FiraSans-Bold.ttf");
     let font_medium = asset_server.load("fonts/FiraMono-Medium.ttf");
 
-    commands.spawn((
-        TextBundle::from_sections([
-            TextSection::new(
-                "FPS: ",
-                TextStyle {
-                    font: font_bold.clone(),
-                    font_size: 30.0,
-                    color: Color::WHITE,
-                },
-            ),
-            TextSection::from_style(TextStyle {
-                font: font_medium.clone(),
-                font_size: 30.0,
-                color: Color::from(GOLD),
-            }),
-            TextSection::new(
-                "\n(min: ",
-                TextStyle {
-                    font: font_bold.clone(),
-                    font_size: 20.0,
-                    color: Color::WHITE,
-                },
-            ),
-            TextSection::from_style(TextStyle {
-                font: font_medium.clone(),
-                font_size: 20.0,
-                color: Color::from(GOLD),
-            }),
-            TextSection::new(
-                " - max: ",
-                TextStyle {
-                    font: font_bold.clone(),
-                    font_size: 20.0,
-                    color: Color::WHITE,
-                },
-            ),
-            TextSection::from_style(TextStyle {
-                font: font_medium.clone(),
-                font_size: 20.0,
-                color: Color::from(GOLD),
-            }),
-            TextSection::new(
-                ")",
-                TextStyle {
-                    font: font_bold.clone(),
-                    font_size: 20.0,
-                    color: Color::WHITE,
-                },
-            ),
-            TextSection::new(
-                "\nms/frame: ",
-                TextStyle {
-                    font: font_bold.clone(),
-                    font_size: 30.0,
-                    color: Color::WHITE,
-                },
-            ),
-            TextSection::from_style(TextStyle {
-                font: font_medium.clone(),
-                font_size: 30.0,
-                color: Color::from(GREEN),
-            }),
-        ])
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            top: Val::Px(5.0),
-            left: Val::Px(15.0),
-            ..default()
-        }),
-        FpsText,
-    ));
+    commands
+        .spawn((
+            Text::default(),
+            TextColor::WHITE,
+            TextFont::from_font(font_medium).with_font_size(20.0),
+            Node {
+                position_type: PositionType::Absolute,
+                top: Val::Px(5.0),
+                left: Val::Px(15.0),
+                ..default()
+            },
+        ))
+        .with_children(|commands| {
+            commands.spawn((
+                TextSpan::new("FPS: "),
+                TextFont::from_font(font_bold.clone()).with_font_size(30.0),
+            ));
+            commands.spawn((
+                TextSpan::default(),
+                TextFont::from_font_size(30.0),
+                TextColor::from(GOLD),
+                FpsText,
+            ));
+            commands.spawn((
+                TextSpan::new("\n(min: "),
+                TextFont::from_font(font_bold.clone()),
+            ));
+            commands.spawn((TextSpan::default(), TextColor::from(GOLD), FpsMinText));
+            commands.spawn((
+                TextSpan::new(" - max: "),
+                TextFont::from_font(font_bold.clone()),
+            ));
+            commands.spawn((TextSpan::default(), TextColor::from(GOLD), FpsMaxText));
+            commands.spawn((TextSpan::new(")"), TextFont::from_font(font_bold.clone())));
+            commands.spawn((
+                TextSpan::new("\nms/frame: "),
+                TextFont::from_font(font_bold.clone()).with_font_size(30.0),
+            ));
+            commands.spawn((
+                TextSpan::default(),
+                TextFont::from_font_size(30.0),
+                TextColor::from(GREEN),
+                FrameTimeText,
+            ));
+        });
 }
 
 fn fps_text_update_system(
     diagnostics: Res<DiagnosticsStore>,
     mut fps_values: Local<FpsValues>,
-    mut query: Query<&mut Text, With<FpsText>>,
+    mut query: ParamSet<(
+        Query<&mut TextSpan, With<FpsText>>,
+        Query<&mut TextSpan, With<FpsMinText>>,
+        Query<&mut TextSpan, With<FpsMaxText>>,
+        Query<&mut TextSpan, With<FrameTimeText>>,
+    )>,
 ) {
-    for mut text in &mut query {
-        if let Some(fps) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FPS) {
-            if let Some(fps_smoothed) = fps.smoothed() {
-                // Update the value of the second section
-                text.sections[1].value = format!("{fps_smoothed:.2}");
-                fps_values.min = fps_values.min.min(fps_smoothed);
-                text.sections[3].value = format!("{:.2}", fps_values.min);
-                fps_values.max = fps_values.max.max(fps_smoothed);
-                text.sections[5].value = format!("{:.2}", fps_values.max);
+    if let Some(fps) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FPS) {
+        if let Some(fps_smoothed) = fps.smoothed() {
+            if let Ok(mut text) = query.p0().get_single_mut() {
+                *text.write_span() = format!("{fps_smoothed:.2}");
+            }
+            fps_values.min = fps_values.min.min(fps_smoothed);
+            if let Ok(mut text) = query.p1().get_single_mut() {
+                *text.write_span() = format!("{:.2}", fps_values.min);
+            }
+            fps_values.max = fps_values.max.max(fps_smoothed);
+            if let Ok(mut text) = query.p2().get_single_mut() {
+                *text.write_span() = format!("{:.2}", fps_values.max);
             }
         }
-        if let Some(frame_time) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FRAME_TIME) {
-            if let Some(frame_time_smoothed) = frame_time.smoothed() {
-                text.sections[8].value = format!("{frame_time_smoothed:.2}");
+    }
+    if let Some(frame_time) = diagnostics.get(&FrameTimeDiagnosticsPlugin::FRAME_TIME) {
+        if let Some(frame_time_smoothed) = frame_time.smoothed() {
+            if let Ok(mut text) = query.p3().get_single_mut() {
+                *text.write_span() = format!("{frame_time_smoothed:.2}");
             }
         }
     }
@@ -275,39 +229,31 @@ fn setup_origin_text(mut commands: Commands, asset_server: Res<AssetServer>) {
     let font_bold = asset_server.load("fonts/FiraSans-Bold.ttf");
     let font_medium = asset_server.load("fonts/FiraMono-Medium.ttf");
 
-    commands.spawn((
-        TextBundle::from_sections([
-            TextSection::new(
-                "Origin: ",
-                TextStyle {
-                    font: font_bold.clone(),
-                    font_size: 20.0,
-                    color: Color::WHITE,
-                },
-            ),
-            TextSection::from_style(TextStyle {
-                font: font_medium.clone(),
-                font_size: 20.0,
-                color: Color::from(GOLD),
-            }),
-        ])
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            bottom: Val::Px(5.0),
-            left: Val::Px(15.0),
-            ..default()
-        }),
-        OriginText,
-    ));
+    commands
+        .spawn((
+            Text::default(),
+            TextColor::WHITE,
+            TextFont::from_font(font_medium).with_font_size(20.0),
+            Node {
+                position_type: PositionType::Absolute,
+                bottom: Val::Px(5.0),
+                left: Val::Px(15.0),
+                ..default()
+            },
+        ))
+        .with_children(|commands| {
+            commands.spawn((TextSpan::new("Origin: "), TextFont::from_font(font_bold)));
+            commands.spawn((TextSpan::default(), TextColor::from(GOLD), OriginText));
+        });
 }
 
 fn origin_text_update_system(
-    mut text_query: Query<&mut Text, (With<OriginText>, Without<Origin>)>,
-    query: Query<&Origin, Without<Text>>,
+    mut text_query: Query<&mut TextSpan, With<OriginText>>,
+    query: Query<&Origin>,
 ) {
     for mut text in &mut text_query {
         if let Some(origin) = query.iter().next() {
-            text.sections[1].value = format!("{origin:?}");
+            *text.write_span() = format!("{origin:?}");
         }
     }
 }

--- a/examples/common/lib.rs
+++ b/examples/common/lib.rs
@@ -34,7 +34,7 @@ fn setup_legend(mut commands: Commands, asset_server: Res<AssetServer>) {
     let font_bold = asset_server.load("fonts/FiraSans-Bold.ttf");
     let font_medium = asset_server.load("fonts/FiraMono-Medium.ttf");
 
-    commands.spawn((TextBundle::from_sections([
+    commands.spawn((Text::from_sections([
         TextSection::new(
             "Key Info",
             TextStyle {
@@ -107,13 +107,17 @@ pub struct DontChange;
 /// origin when 'O' is pressed.
 fn keyboard_input_system(
     keyboard_input: Res<ButtonInput<KeyCode>>,
-    mut svg_query: Query<(&mut Origin, &mut Visibility), (With<Handle<Svg>>, Without<DontChange>)>,
+    mut svg_query: Query<
+        (&mut Origin, &mut Visibility),
+        (Or<(With<Svg2d>, With<Svg3d>)>, Without<DontChange>),
+    >,
     mut ui_query: Query<
         &mut Visibility,
         (
             With<Text>,
             Or<(With<FpsText>, With<OriginText>)>,
-            Without<Handle<Svg>>,
+            Without<Svg2d>,
+            Without<Svg3d>,
         ),
     >,
 ) {
@@ -132,7 +136,7 @@ fn keyboard_input_system(
                 Origin::Center => Origin::BottomLeft,
                 Origin::TopLeft => Origin::Center,
                 Origin::TopRight => Origin::TopLeft,
-                Origin::Custom(coord) => Origin::Custom(*coord)
+                Origin::Custom(coord) => Origin::Custom(*coord),
             }
         }
     } else if keyboard_input.just_pressed(KeyCode::KeyF) {

--- a/examples/common/lib.rs
+++ b/examples/common/lib.rs
@@ -76,7 +76,7 @@ fn keyboard_input_system(
         &mut Visibility,
         (
             With<Text>,
-            Or<(With<FpsText>, With<OriginText>)>,
+            Or<(With<FpsTextRoot>, With<OriginTextRoot>)>,
             Without<Svg2d>,
             Without<Svg3d>,
         ),
@@ -122,6 +122,9 @@ struct FpsMaxText;
 #[derive(Component)]
 struct FrameTimeText;
 
+#[derive(Component)]
+struct FpsTextRoot;
+
 #[derive(Resource)]
 struct FpsValues {
     min: f64,
@@ -152,6 +155,7 @@ fn setup_fps_counter(mut commands: Commands, asset_server: Res<AssetServer>) {
                 left: Val::Px(15.0),
                 ..default()
             },
+            FpsTextRoot,
         ))
         .with_children(|commands| {
             commands.spawn((
@@ -225,6 +229,9 @@ fn fps_text_update_system(
 #[derive(Component)]
 struct OriginText;
 
+#[derive(Component)]
+struct OriginTextRoot;
+
 fn setup_origin_text(mut commands: Commands, asset_server: Res<AssetServer>) {
     let font_bold = asset_server.load("fonts/FiraSans-Bold.ttf");
     let font_medium = asset_server.load("fonts/FiraMono-Medium.ttf");
@@ -240,6 +247,7 @@ fn setup_origin_text(mut commands: Commands, asset_server: Res<AssetServer>) {
                 left: Val::Px(15.0),
                 ..default()
             },
+            OriginTextRoot,
         ))
         .with_children(|commands| {
             commands.spawn((TextSpan::new("Origin: "), TextFont::from_font(font_bold)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,9 @@ pub mod prelude {
     #[cfg(any(feature = "2d", feature = "3d"))]
     pub use crate::origin::Origin;
     #[cfg(feature = "2d")]
-    pub use crate::render::Svg2dBundle;
+    pub use crate::render::{Svg2d, Svg2dBundle};
     #[cfg(feature = "3d")]
-    pub use crate::render::Svg3dBundle;
+    pub use crate::render::{Svg3d, Svg3dBundle};
     pub use crate::svg::Svg;
     pub use lyon_tessellation::{
         FillOptions, FillRule, LineCap, LineJoin, Orientation, StrokeOptions,

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},
+    asset::{io::Reader, AssetLoader, LoadContext},
     log::debug,
     utils::ConditionalSendFuture,
 };
@@ -15,11 +15,11 @@ impl AssetLoader for SvgAssetLoader {
     type Settings = ();
     type Error = FileSvgError;
 
-    fn load<'load>(
-        &'load self,
-        reader: &'load mut Reader,
-        _settings: &'load (),
-        load_context: &'load mut LoadContext,
+    fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &(),
+        load_context: &mut LoadContext<'_>,
     ) -> impl ConditionalSendFuture<Output = Result<Self::Asset, Self::Error>> {
         Box::pin(async move {
             debug!("Parsing SVG: {} ...", load_context.path().display());

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -23,8 +23,10 @@ use bevy::{
     },
     hierarchy::DespawnRecursiveExt,
     log::debug,
+    pbr::MeshMaterial3d,
     prelude::{Last, PostUpdate},
     render::mesh::Mesh,
+    sprite::MeshMaterial2d,
 };
 
 #[cfg(feature = "2d")]
@@ -64,6 +66,7 @@ impl Plugin for SvgRenderPlugin {
 #[cfg(not(feature = "3d"))]
 type SvgMeshComponents = (
     Entity,
+    &'static mut MeshMaterial2d<Svg>,
     &'static Handle<Svg>,
     Option<&'static mut Mesh2dHandle>,
     Option<()>,
@@ -72,6 +75,7 @@ type SvgMeshComponents = (
 #[cfg(feature = "3d")]
 type SvgMeshComponents = (
     Entity,
+    &'static mut MeshMaterial3d<Svg>,
     &'static Handle<Svg>,
     Option<()>,
     Option<&'static mut Handle<Mesh>>,
@@ -79,6 +83,8 @@ type SvgMeshComponents = (
 #[cfg(all(feature = "2d", feature = "3d"))]
 type SvgMeshComponents = (
     Entity,
+    Option<&'static mut MeshMaterial2d<Svg>>,
+    Option<&'static mut MeshMaterial3d<Svg>>,
     Option<&'static Svg2d>,
     Option<&'static Svg3d>,
     Option<&'static mut Mesh2d>,
@@ -101,34 +107,53 @@ fn svg_mesh_linker(
         match event {
             AssetEvent::Added { .. } => (),
             AssetEvent::LoadedWithDependencies { id } => {
-                for (.., mesh_2d, mesh_3d) in query.iter_mut().filter(|(_, svg_2d, svg_3d, ..)| {
-                    svg_2d
-                        .map(|x| x.0.id() == *id)
-                        .or_else(|| svg_3d.map(|x| x.0.id() == *id))
-                        .unwrap_or(false)
-                }) {
+                for (.., mut material_2d, mut material_3d, svg_2d, svg_3d, mesh_2d, mesh_3d) in
+                    query.iter_mut().filter(|(_, _, _, svg_2d, svg_3d, ..)| {
+                        svg_2d
+                            .map(|x| x.0.id() == *id)
+                            .or_else(|| svg_3d.map(|x| x.0.id() == *id))
+                            .unwrap_or(false)
+                    })
+                {
                     let svg = svgs.get(*id).unwrap();
                     debug!(
                         "Svg `{}` created. Adding mesh component to entity.",
                         svg.name
                     );
                     #[cfg(feature = "2d")]
-                    if let Some(mut mesh) = mesh_2d {
-                        mesh.0 = svg.mesh.clone();
+                    {
+                        if let Some(mut mesh) = mesh_2d {
+                            mesh.0 = svg.mesh.clone();
+                        }
+
+                        if let (Some(svg_2d), Some(mut material_2d)) = (svg_2d, material_2d) {
+                            let handle = svg_2d.0.clone();
+                            material_2d.0 = handle;
+                        }
                     }
                     #[cfg(feature = "3d")]
-                    if let Some(mut mesh) = mesh_3d {
-                        mesh.0 = svg.mesh.clone();
+                    {
+
+                        if let Some(mut mesh) = mesh_3d {
+                            mesh.0 = svg.mesh.clone();
+                        }
+
+                        if let (Some(svg_3d), Some(mut material_3d)) = (svg_3d, material_3d) {
+                            let handle = svg_3d.0.clone();
+                            material_3d.0 = handle;
+                        }
                     }
                 }
             }
             AssetEvent::Modified { id } => {
-                for (.., mesh_2d, mesh_3d) in query.iter_mut().filter(|(_, svg_2d, svg_3d, ..)| {
-                    svg_2d
-                        .map(|x| x.0.id() == *id)
-                        .or_else(|| svg_3d.map(|x| x.0.id() == *id))
-                        .unwrap_or(false)
-                }) {
+                for (.., mesh_2d, mesh_3d) in
+                    query.iter_mut().filter(|(_, _, _, svg_2d, svg_3d, ..)| {
+                        svg_2d
+                            .map(|x| x.0.id() == *id)
+                            .or_else(|| svg_3d.map(|x| x.0.id() == *id))
+                            .unwrap_or(false)
+                    })
+                {
                     let svg = svgs.get(*id).unwrap();
                     debug!(
                         "Svg `{}` modified. Changing mesh component of entity.",
@@ -149,7 +174,7 @@ fn svg_mesh_linker(
                 }
             }
             AssetEvent::Removed { id } => {
-                for (entity, ..) in query.iter_mut().filter(|(_, svg_2d, svg_3d, ..)| {
+                for (entity, ..) in query.iter_mut().filter(|(_, _, _, svg_2d, svg_3d, ..)| {
                     svg_2d
                         .map(|x| x.0.id() == *id)
                         .or_else(|| svg_3d.map(|x| x.0.id() == *id))

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -8,8 +8,8 @@ mod svg2d;
 mod svg3d;
 
 #[cfg(feature = "2d")]
-pub use svg2d::Svg2dBundle;
+pub use svg2d::{Svg2d, Svg2dBundle};
 #[cfg(feature = "3d")]
-pub use svg3d::Svg3dBundle;
+pub use svg3d::{Svg3d, Svg3dBundle};
 
 pub use plugin::SvgPlugin;

--- a/src/render/svg2d/bundle.rs
+++ b/src/render/svg2d/bundle.rs
@@ -1,21 +1,28 @@
 //! Bevy [`Bundle`] representing an SVG entity.
 
 use bevy::{
-    asset::Handle,
     ecs::bundle::Bundle,
-    render::view::{InheritedVisibility, ViewVisibility, Visibility},
-    sprite::Mesh2dHandle,
+    render::{
+        mesh::Mesh2d,
+        view::{InheritedVisibility, ViewVisibility, Visibility},
+    },
     transform::components::{GlobalTransform, Transform},
 };
 
-use crate::{origin::Origin, svg::Svg};
+use crate::origin::Origin;
+
+use super::Svg2d;
 
 /// A Bevy [`Bundle`] representing an SVG entity.
 #[allow(missing_docs)]
-#[derive(Bundle)]
+#[derive(Bundle, Default)]
+#[deprecated(
+    since = "0.15.0",
+    note = "Use the `Svg2d` component instead. Inserting `Svg2d` will also insert the other components required automatically."
+)]
 pub struct Svg2dBundle {
-    pub svg: Handle<Svg>,
-    pub mesh_2d: Mesh2dHandle,
+    pub svg: Svg2d,
+    pub mesh_2d: Mesh2d,
     /// [`Origin`] of the coordinate system and as such the origin for the Bevy position.
     pub origin: Origin,
     pub transform: Transform,
@@ -23,20 +30,4 @@ pub struct Svg2dBundle {
     pub visibility: Visibility,
     pub inherited_visibility: InheritedVisibility,
     pub view_visibility: ViewVisibility,
-}
-
-impl Default for Svg2dBundle {
-    /// Creates a default [`Svg2dBundle`].
-    fn default() -> Self {
-        Self {
-            svg: Default::default(),
-            mesh_2d: Default::default(),
-            origin: Default::default(),
-            transform: Transform::default(),
-            global_transform: GlobalTransform::default(),
-            visibility: Visibility::default(),
-            inherited_visibility: InheritedVisibility::default(),
-            view_visibility: ViewVisibility::default(),
-        }
-    }
 }

--- a/src/render/svg2d/mod.rs
+++ b/src/render/svg2d/mod.rs
@@ -1,6 +1,6 @@
 use crate::{origin::Origin, svg::Svg};
 use bevy::{
-    asset::Handle, ecs::component::Component, render::{mesh::Mesh2d, render_resource::Shader}, sprite::MeshMaterial2d,
+    asset::Handle, ecs::{component::{self, Component, ComponentId}, world::DeferredWorld}, prelude::{Entity, Query}, render::{mesh::Mesh2d, render_resource::Shader}, sprite::MeshMaterial2d
 };
 
 mod bundle;
@@ -14,5 +14,14 @@ pub use plugin::RenderPlugin;
 
 /// A component for 2D SVGs.
 #[derive(Component, Default)]
-#[require(Mesh2d, Origin, MeshMaterial2d<Svg>)]
+#[require(Mesh2d, Origin)]
+#[component(on_insert = svg_2d_on_insert)]
 pub struct Svg2d(pub Handle<Svg>);
+
+fn svg_2d_on_insert(mut world: DeferredWorld, entity: Entity, component_id: ComponentId) {
+    let component = world.entity(entity).get_components::<&Svg2d>().unwrap();
+    let handle = component.0.clone();
+    let entity = world.entity(entity).id();
+    let mut commands = world.commands();
+    commands.entity(entity).insert(MeshMaterial2d(handle));
+}

--- a/src/render/svg2d/mod.rs
+++ b/src/render/svg2d/mod.rs
@@ -1,4 +1,7 @@
-use bevy::{asset::Handle, render::render_resource::Shader};
+use crate::{origin::Origin, svg::Svg};
+use bevy::{
+    asset::Handle, ecs::component::Component, render::mesh::Mesh2d, render::render_resource::Shader,
+};
 
 mod bundle;
 mod plugin;
@@ -8,3 +11,7 @@ pub const SVG_2D_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(8_514_82
 
 pub use bundle::Svg2dBundle;
 pub use plugin::RenderPlugin;
+
+#[derive(Component, Default)]
+#[require(Mesh2d, Origin)]
+pub struct Svg2d(pub Handle<Svg>);

--- a/src/render/svg2d/mod.rs
+++ b/src/render/svg2d/mod.rs
@@ -12,6 +12,7 @@ pub const SVG_2D_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(8_514_82
 pub use bundle::Svg2dBundle;
 pub use plugin::RenderPlugin;
 
+/// A component for 2D SVGs.
 #[derive(Component, Default)]
 #[require(Mesh2d, Origin)]
 pub struct Svg2d(pub Handle<Svg>);

--- a/src/render/svg2d/mod.rs
+++ b/src/render/svg2d/mod.rs
@@ -1,6 +1,6 @@
 use crate::{origin::Origin, svg::Svg};
 use bevy::{
-    asset::Handle, ecs::component::Component, render::mesh::Mesh2d, render::render_resource::Shader,
+    asset::Handle, ecs::component::Component, render::{mesh::Mesh2d, render_resource::Shader}, sprite::MeshMaterial2d,
 };
 
 mod bundle;
@@ -14,5 +14,5 @@ pub use plugin::RenderPlugin;
 
 /// A component for 2D SVGs.
 #[derive(Component, Default)]
-#[require(Mesh2d, Origin)]
+#[require(Mesh2d, Origin, MeshMaterial2d<Svg>)]
 pub struct Svg2d(pub Handle<Svg>);

--- a/src/render/svg3d/bundle.rs
+++ b/src/render/svg3d/bundle.rs
@@ -1,23 +1,28 @@
 //! Bevy [`Bundle`] representing an SVG entity.
 
 use bevy::{
-    asset::Handle,
     ecs::bundle::Bundle,
     render::{
-        mesh::Mesh,
+        mesh::Mesh3d,
         view::{InheritedVisibility, ViewVisibility, Visibility},
     },
     transform::components::{GlobalTransform, Transform},
 };
 
-use crate::{origin::Origin, svg::Svg};
+use crate::origin::Origin;
+
+use super::Svg3d;
 
 /// A Bevy [`Bundle`] representing an SVG entity.
 #[allow(missing_docs)]
-#[derive(Bundle)]
+#[derive(Bundle, Default)]
+#[deprecated(
+    since = "0.15.0",
+    note = "Use the `Svg3d` component instead. Inserting `Svg3d` will also insert the other components required automatically."
+)]
 pub struct Svg3dBundle {
-    pub svg: Handle<Svg>,
-    pub mesh: Handle<Mesh>,
+    pub svg: Svg3d,
+    pub mesh: Mesh3d,
     /// [`Origin`] of the coordinate system and as such the origin for the Bevy position.
     pub origin: Origin,
     pub transform: Transform,
@@ -25,20 +30,4 @@ pub struct Svg3dBundle {
     pub visibility: Visibility,
     pub inherited_visibility: InheritedVisibility,
     pub view_visibility: ViewVisibility,
-}
-
-impl Default for Svg3dBundle {
-    /// Creates a default [`Svg3dBundle`].
-    fn default() -> Self {
-        Self {
-            svg: Default::default(),
-            mesh: Default::default(),
-            origin: Default::default(),
-            transform: Transform::default(),
-            global_transform: GlobalTransform::default(),
-            visibility: Visibility::default(),
-            inherited_visibility: InheritedVisibility::default(),
-            view_visibility: ViewVisibility::default(),
-        }
-    }
 }

--- a/src/render/svg3d/mod.rs
+++ b/src/render/svg3d/mod.rs
@@ -1,4 +1,8 @@
-use bevy::{asset::Handle, render::render_resource::Shader};
+use bevy::{
+    asset::Handle,
+    ecs::component::Component,
+    render::{mesh::Mesh3d, render_resource::Shader},
+};
 
 mod bundle;
 mod plugin;
@@ -8,3 +12,9 @@ pub const SVG_3D_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(8_514_82
 
 pub use bundle::Svg3dBundle;
 pub use plugin::RenderPlugin;
+
+use crate::{origin::Origin, svg::Svg};
+
+#[derive(Component, Default)]
+#[require(Mesh3d, Origin)]
+pub struct Svg3d(pub Handle<Svg>);

--- a/src/render/svg3d/mod.rs
+++ b/src/render/svg3d/mod.rs
@@ -1,7 +1,5 @@
 use bevy::{
-    asset::Handle,
-    ecs::component::Component,
-    render::{mesh::Mesh3d, render_resource::Shader},
+    asset::Handle, ecs::component::Component, pbr::MeshMaterial3d, render::{mesh::Mesh3d, render_resource::Shader}
 };
 
 mod bundle;
@@ -17,5 +15,5 @@ use crate::{origin::Origin, svg::Svg};
 
 /// A component for 3D SVGs.
 #[derive(Component, Default)]
-#[require(Mesh3d, Origin)]
+#[require(Mesh3d, Origin, MeshMaterial3d<Svg>)]
 pub struct Svg3d(pub Handle<Svg>);

--- a/src/render/svg3d/mod.rs
+++ b/src/render/svg3d/mod.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    asset::Handle, ecs::component::Component, pbr::MeshMaterial3d, render::{mesh::Mesh3d, render_resource::Shader}
+    asset::Handle, ecs::{component::{Component, ComponentId}, world::DeferredWorld}, pbr::MeshMaterial3d, prelude::Entity, render::{mesh::Mesh3d, render_resource::Shader}
 };
 
 mod bundle;
@@ -16,4 +16,13 @@ use crate::{origin::Origin, svg::Svg};
 /// A component for 3D SVGs.
 #[derive(Component, Default)]
 #[require(Mesh3d, Origin, MeshMaterial3d<Svg>)]
+#[component(on_insert = svg_3d_on_insert)]
 pub struct Svg3d(pub Handle<Svg>);
+
+fn svg_3d_on_insert(mut world: DeferredWorld, entity: Entity, _component_id: ComponentId) {
+    let component = world.entity(entity).get_components::<&Svg3d>().unwrap();
+    let handle = component.0.clone();
+    let entity = world.entity(entity).id();
+    let mut commands = world.commands();
+    commands.entity(entity).insert(MeshMaterial3d(handle));
+}

--- a/src/render/svg3d/mod.rs
+++ b/src/render/svg3d/mod.rs
@@ -15,6 +15,7 @@ pub use plugin::RenderPlugin;
 
 use crate::{origin::Origin, svg::Svg};
 
+/// A component for 3D SVGs.
 #[derive(Component, Default)]
 #[require(Mesh3d, Origin)]
 pub struct Svg3d(pub Handle<Svg>);


### PR DESCRIPTION
Continuation of #44 

Looks like the issue is that the new `Mesh#d` components require a `MeshMaterial#d` component to render their content. I added a few lines to `svg_mesh_linker` to update the handles in the `default` implementations for these components. [Details](https://bevyengine.org/learn/migration-guides/0-14-to-0-15/#migrate-meshes-and-materials-to-required-components)

It looks like it works for both `2d` and `3d` examples.