### PR TITLE
Publically expose SvgSet so third-party plugins can sequence around it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ pub mod prelude {
     };
 }
 
+pub use plugin::SvgSet;
+
 #[cfg(any(feature = "2d", feature = "3d"))]
 use crate::plugin::SvgRenderPlugin;
 use crate::{loader::SvgAssetLoader, svg::Svg};

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -39,23 +39,17 @@ use crate::{
     svg::Svg,
 };
 
-/// Sets for this plugin.
+/// Set in which [`Svg`](crate::prelude::Svg2d)s get drawn.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-pub enum SvgSet {
-    /// Set in which [`Svg2dBundle`](crate::bundle::Svg2dBundle)s get drawn.
-    Svg, // TODO: do we need this? Would it be more useful to split the different parts of this set?
-}
+pub struct SvgSet;
 
 /// A plugin that makes sure your [`Svg`]s get rendered
 pub struct SvgRenderPlugin;
 
 impl Plugin for SvgRenderPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(PostUpdate, (origin::add_origin_state.in_set(SvgSet::Svg),))
-            .add_systems(
-                Last,
-                (origin::apply_origin, svg_mesh_linker.in_set(SvgSet::Svg)),
-            )
+        app.add_systems(PostUpdate, origin::add_origin_state.in_set(SvgSet))
+            .add_systems(Last, (origin::apply_origin, svg_mesh_linker.in_set(SvgSet)))
             .add_plugins(render::SvgPlugin);
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -41,9 +41,9 @@ use crate::{
 
 /// Sets for this plugin.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-pub enum Set {
+pub enum SvgSet {
     /// Set in which [`Svg2dBundle`](crate::bundle::Svg2dBundle)s get drawn.
-    SVG,
+    Svg, // TODO: do we need this? Would it be more useful to split the different parts of this set?
 }
 
 /// A plugin that makes sure your [`Svg`]s get rendered
@@ -51,10 +51,10 @@ pub struct SvgRenderPlugin;
 
 impl Plugin for SvgRenderPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(PostUpdate, (origin::add_origin_state.in_set(Set::SVG),))
+        app.add_systems(PostUpdate, (origin::add_origin_state.in_set(SvgSet::Svg),))
             .add_systems(
                 Last,
-                (origin::apply_origin, svg_mesh_linker.in_set(Set::SVG)),
+                (origin::apply_origin, svg_mesh_linker.in_set(SvgSet::Svg)),
             )
             .add_plugins(render::SvgPlugin);
     }


### PR DESCRIPTION
Fixes #47.

Simple PR, would be a one-liner if I didn't update some naming conventions for ease of use (e.g. `Set` is too generic to be exposed in an API imo).