### PR TITLE
Update to Bevy 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "bevy_svg"
 readme = "README.md"
 repository = "https://github.com/Weasy666/bevy_svg/"
-version = "0.16.0-rc1"
+version = "0.17.0"
 keywords = ["gamedev", "graphics", "bevy", "svg"]
 categories = ["game-engines", "game-development", "graphics", "multimedia", "rendering"]
 exclude = ["assets", "examples"]
@@ -21,7 +21,7 @@ default = ["2d", "3d"]
 3d = ["bevy/bevy_pbr"]
 
 [dependencies]
-bevy = { version = "0.16", default-features = false, features = ["bevy_asset", "bevy_core_pipeline", "bevy_log", "bevy_render"] }
+bevy = { version = "0.17", default-features = false, features = ["bevy_asset", "bevy_core_pipeline", "bevy_log", "bevy_render", "bevy_sprite_render"] }
 copyless = "0.1"
 
 lyon_geom = "1.0"
@@ -34,7 +34,7 @@ anyhow = "1.0"
 thiserror = "2.0"
 
 [dev-dependencies]
-bevy = { version = "0.16", default-features = true }
+bevy = { version = "0.17", default-features = true }
 
 #### 2D examples ####
 [[example]]

--- a/examples/2d/complex_one_color.rs
+++ b/examples/2d/complex_one_color.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "2d_complex_one_color".to_string(),
-                resolution: (600., 600.).into(),
+                resolution: (600, 600).into(),
                 ..Default::default()
             }),
             ..Default::default()

--- a/examples/2d/multiple_translation.rs
+++ b/examples/2d/multiple_translation.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "2d_multiple_translation".to_string(),
-                resolution: (600., 600.).into(),
+                resolution: (600, 600).into(),
                 ..Default::default()
             }),
             ..Default::default()

--- a/examples/2d/origin_check.rs
+++ b/examples/2d/origin_check.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "origin_check".to_string(),
-                resolution: (600., 600.).into(),
+                resolution: (600, 600).into(),
                 ..Default::default()
             }),
             ..Default::default()

--- a/examples/2d/preloading.rs
+++ b/examples/2d/preloading.rs
@@ -10,7 +10,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "preloading".to_string(),
-                resolution: (600., 600.).into(),
+                resolution: (600, 600).into(),
                 ..Default::default()
             }),
             ..Default::default()

--- a/examples/2d/twinkle.rs
+++ b/examples/2d/twinkle.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "2d_twinkle".to_string(),
-                resolution: (600., 600.).into(),
+                resolution: (600, 600).into(),
                 ..Default::default()
             }),
             ..Default::default()

--- a/examples/2d/two_colors.rs
+++ b/examples/2d/two_colors.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "2d_two_colors".to_string(),
-                resolution: (600., 600.).into(),
+                resolution: (600, 600).into(),
                 ..Default::default()
             }),
             ..Default::default()

--- a/examples/3d/complex_one_color.rs
+++ b/examples/3d/complex_one_color.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "3d_complex_one_color".to_string(),
-                resolution: (600., 600.).into(),
+                resolution: (600, 600).into(),
                 ..Default::default()
             }),
             ..Default::default()

--- a/examples/3d/multiple_perspective.rs
+++ b/examples/3d/multiple_perspective.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "3d_multiple_perspective".to_string(),
-                resolution: (600., 600.).into(),
+                resolution: (600, 600).into(),
                 ..Default::default()
             }),
             ..Default::default()

--- a/examples/3d/multiple_translation.rs
+++ b/examples/3d/multiple_translation.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "3d_multiple_translation".to_string(),
-                resolution: (600., 600.).into(),
+                resolution: (600, 600).into(),
                 ..Default::default()
             }),
             ..Default::default()

--- a/examples/3d/origin_check.rs
+++ b/examples/3d/origin_check.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "origin_check".to_string(),
-                resolution: (600., 600.).into(),
+                resolution: (600, 600).into(),
                 ..Default::default()
             }),
             ..Default::default()

--- a/examples/3d/twinkle.rs
+++ b/examples/3d/twinkle.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "3d_twinkle".to_string(),
-                resolution: (600., 600.).into(),
+                resolution: (600, 600).into(),
                 ..Default::default()
             }),
             ..Default::default()

--- a/examples/3d/two_colors.rs
+++ b/examples/3d/two_colors.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "3d_two_colors".to_string(),
-                resolution: (600., 600.).into(),
+                resolution: (600, 600).into(),
                 ..Default::default()
             }),
             ..Default::default()

--- a/examples/common/lib.rs
+++ b/examples/common/lib.rs
@@ -39,7 +39,7 @@ fn setup_legend(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn((
             Text::default(),
             TextColor::WHITE,
-            TextFont::from_font(font_medium).with_font_size(20.0),
+            TextFont::from_font_size(20.0).with_font(font_medium),
             Node {
                 position_type: PositionType::Absolute,
                 top: Val::Px(5.0),
@@ -50,13 +50,22 @@ fn setup_legend(mut commands: Commands, asset_server: Res<AssetServer>) {
         .with_children(|commands| {
             commands.spawn((
                 TextSpan::new("Key Info"),
-                TextFont::from_font(font_bold.clone()).with_font_size(30.0),
+                TextFont::from_font_size(30.0).with_font(font_bold.clone()),
             ));
-            commands.spawn((TextSpan::new("\nF"), TextFont::from_font(font_bold.clone())));
+            commands.spawn((
+                TextSpan::new("\nF"),
+                TextFont::from_font_size(20.0).with_font(font_bold.clone()),
+            ));
             commands.spawn(TextSpan::new(" - Toggle Frame Diagnostics"));
-            commands.spawn((TextSpan::new("\nO"), TextFont::from_font(font_bold.clone())));
+            commands.spawn((
+                TextSpan::new("\nO"),
+                TextFont::from_font_size(20.0).with_font(font_bold.clone()),
+            ));
             commands.spawn(TextSpan::new(" - Cycle through Origins"));
-            commands.spawn((TextSpan::new("\nV"), TextFont::from_font(font_bold.clone())));
+            commands.spawn((
+                TextSpan::new("\nV"),
+                TextFont::from_font_size(20.0).with_font(font_bold.clone()),
+            ));
             commands.spawn(TextSpan::new(" - Toggle visibility"));
         });
 }
@@ -148,7 +157,7 @@ fn setup_fps_counter(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn((
             Text::default(),
             TextColor::WHITE,
-            TextFont::from_font(font_medium).with_font_size(20.0),
+            TextFont::from_font_size(20.0).with_font(font_medium),
             Node {
                 position_type: PositionType::Absolute,
                 top: Val::Px(5.0),
@@ -160,7 +169,7 @@ fn setup_fps_counter(mut commands: Commands, asset_server: Res<AssetServer>) {
         .with_children(|commands| {
             commands.spawn((
                 TextSpan::new("FPS: "),
-                TextFont::from_font(font_bold.clone()).with_font_size(30.0),
+                TextFont::from_font_size(30.0).with_font(font_bold.clone()),
             ));
             commands.spawn((
                 TextSpan::default(),
@@ -170,18 +179,21 @@ fn setup_fps_counter(mut commands: Commands, asset_server: Res<AssetServer>) {
             ));
             commands.spawn((
                 TextSpan::new("\n(min: "),
-                TextFont::from_font(font_bold.clone()),
+                TextFont::from_font_size(20.0).with_font(font_bold.clone()),
             ));
             commands.spawn((TextSpan::default(), TextColor::from(GOLD), FpsMinText));
             commands.spawn((
                 TextSpan::new(" - max: "),
-                TextFont::from_font(font_bold.clone()),
+                TextFont::from_font_size(20.0).with_font(font_bold.clone()),
             ));
             commands.spawn((TextSpan::default(), TextColor::from(GOLD), FpsMaxText));
-            commands.spawn((TextSpan::new(")"), TextFont::from_font(font_bold.clone())));
+            commands.spawn((
+                TextSpan::new(")"),
+                TextFont::from_font_size(20.0).with_font(font_bold.clone()),
+            ));
             commands.spawn((
                 TextSpan::new("\nms/frame: "),
-                TextFont::from_font(font_bold.clone()).with_font_size(30.0),
+                TextFont::from_font_size(30.0).with_font(font_bold.clone()),
             ));
             commands.spawn((
                 TextSpan::default(),
@@ -240,7 +252,7 @@ fn setup_origin_text(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn((
             Text::default(),
             TextColor::WHITE,
-            TextFont::from_font(font_medium).with_font_size(20.0),
+            TextFont::from_font_size(20.0).with_font(font_medium),
             Node {
                 position_type: PositionType::Absolute,
                 bottom: Val::Px(5.0),
@@ -250,7 +262,10 @@ fn setup_origin_text(mut commands: Commands, asset_server: Res<AssetServer>) {
             OriginTextRoot,
         ))
         .with_children(|commands| {
-            commands.spawn((TextSpan::new("Origin: "), TextFont::from_font(font_bold)));
+            commands.spawn((
+                TextSpan::new("Origin: "),
+                TextFont::from_font_size(20.0).with_font(font_bold),
+            ));
             commands.spawn((TextSpan::default(), TextColor::from(GOLD), OriginText));
         });
 }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    asset::{io::Reader, AssetLoader, LoadContext},
+    asset::{AssetLoader, LoadContext, io::Reader},
     log::debug,
     tasks::ConditionalSendFuture,
 };

--- a/src/origin.rs
+++ b/src/origin.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "2d")]
-use bevy::render::mesh::Mesh2d;
+use bevy::mesh::Mesh2d;
 #[cfg(feature = "3d")]
-use bevy::render::mesh::Mesh3d;
+use bevy::mesh::Mesh3d;
 use bevy::{
     asset::Assets,
     ecs::{

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -16,14 +16,14 @@ use bevy::{
     asset::{AssetEvent, Assets},
     ecs::{
         entity::Entity,
-        event::EventReader,
+        message::MessageReader,
         query::{Added, Changed, Or},
         schedule::{IntoScheduleConfigs, SystemSet},
         system::{Commands, Query, Res, ResMut},
     },
     log::debug,
-    prelude::{Last, PostUpdate},
     mesh::Mesh,
+    prelude::{Last, PostUpdate},
 };
 
 #[cfg(feature = "2d")]
@@ -81,7 +81,7 @@ type SvgMeshComponents = (
 /// Bevy system which queries for all [`Svg`] bundles and adds the correct [`Mesh`] to them.
 fn svg_mesh_linker(
     mut commands: Commands,
-    mut svg_events: EventReader<AssetEvent<Svg>>,
+    mut svg_events: MessageReader<AssetEvent<Svg>>,
     mut meshes: ResMut<Assets<Mesh>>,
     svgs: Res<Assets<Svg>>,
     mut query: Query<SvgMeshComponents>,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -23,14 +23,14 @@ use bevy::{
     },
     log::debug,
     prelude::{Last, PostUpdate},
-    render::mesh::Mesh,
+    mesh::Mesh,
 };
 
 #[cfg(feature = "2d")]
-use bevy::render::mesh::Mesh2d;
+use bevy::mesh::Mesh2d;
 
 #[cfg(feature = "3d")]
-use bevy::render::mesh::Mesh3d;
+use bevy::mesh::Mesh3d;
 
 use crate::{
     origin,

--- a/src/render/svg2d/bundle.rs
+++ b/src/render/svg2d/bundle.rs
@@ -1,15 +1,12 @@
 //! Bevy [`Bundle`] representing an SVG entity.
 
+use crate::origin::Origin;
 use bevy::{
     ecs::bundle::Bundle,
-    render::{
-        mesh::Mesh2d,
-        view::{InheritedVisibility, ViewVisibility, Visibility},
-    },
+    mesh::Mesh2d,
+    prelude::{InheritedVisibility, ViewVisibility, Visibility},
     transform::components::{GlobalTransform, Transform},
 };
-
-use crate::origin::Origin;
 
 use super::Svg2d;
 

--- a/src/render/svg2d/mod.rs
+++ b/src/render/svg2d/mod.rs
@@ -1,12 +1,10 @@
 use crate::{origin::Origin, svg::Svg};
 use bevy::{
-    asset::{weak_handle, Handle},
-    ecs::{
-        component::{Component, HookContext},
-        world::DeferredWorld,
-    },
-    render::{mesh::Mesh2d, render_resource::Shader},
-    sprite::MeshMaterial2d,
+    asset::{Handle, weak_handle},
+    ecs::{component::Component, lifecycle::HookContext, world::DeferredWorld},
+    mesh::Mesh2d,
+    shader::Shader,
+    sprite_render::MeshMaterial2d,
 };
 
 mod bundle;

--- a/src/render/svg2d/mod.rs
+++ b/src/render/svg2d/mod.rs
@@ -1,6 +1,6 @@
 use crate::{origin::Origin, svg::Svg};
 use bevy::{
-    asset::{Handle, weak_handle},
+    asset::{Handle, uuid_handle},
     ecs::{component::Component, lifecycle::HookContext, world::DeferredWorld},
     mesh::Mesh2d,
     shader::Shader,
@@ -12,7 +12,7 @@ mod plugin;
 
 /// Handle to the custom shader with a unique random ID
 pub const SVG_2D_SHADER_HANDLE: Handle<Shader> =
-    weak_handle!("00000000-0000-0000-762a-bdb29826d266");
+    uuid_handle!("00000000-0000-0000-762a-bdb29826d266");
 
 pub use bundle::Svg2dBundle;
 pub use plugin::RenderPlugin;

--- a/src/render/svg2d/plugin.rs
+++ b/src/render/svg2d/plugin.rs
@@ -1,11 +1,10 @@
+use crate::{render::svg2d::SVG_2D_SHADER_HANDLE, svg::Svg};
 use bevy::{
     app::{App, Plugin},
-    asset::{load_internal_asset, AssetApp},
-    render::render_resource::{Shader, ShaderRef},
-    sprite::{Material2d, Material2dPlugin},
+    asset::{AssetApp, load_internal_asset},
+    shader::{Shader, ShaderRef},
+    sprite_render::{Material2d, Material2dPlugin},
 };
-
-use crate::{render::svg2d::SVG_2D_SHADER_HANDLE, svg::Svg};
 
 /// Plugin that renders [`Svg`](crate::svg::Svg)s in 2D
 pub struct RenderPlugin;

--- a/src/render/svg3d/bundle.rs
+++ b/src/render/svg3d/bundle.rs
@@ -1,15 +1,12 @@
 //! Bevy [`Bundle`] representing an SVG entity.
 
+use crate::origin::Origin;
 use bevy::{
     ecs::bundle::Bundle,
-    render::{
-        mesh::Mesh3d,
-        view::{InheritedVisibility, ViewVisibility, Visibility},
-    },
+    mesh::Mesh3d,
+    prelude::{InheritedVisibility, ViewVisibility, Visibility},
     transform::components::{GlobalTransform, Transform},
 };
-
-use crate::origin::Origin;
 
 use super::Svg3d;
 

--- a/src/render/svg3d/mod.rs
+++ b/src/render/svg3d/mod.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    asset::{Handle, weak_handle},
+    asset::{Handle, uuid_handle},
     ecs::{component::Component, lifecycle::HookContext, world::DeferredWorld},
     mesh::Mesh3d,
     pbr::MeshMaterial3d,
@@ -11,7 +11,7 @@ mod plugin;
 
 /// Handle to the custom shader with a unique random ID
 pub const SVG_3D_SHADER_HANDLE: Handle<Shader> =
-    weak_handle!("00000000-0000-0000-762a-bdb74c2a5c66");
+    uuid_handle!("00000000-0000-0000-762a-bdb74c2a5c66");
 
 pub use bundle::Svg3dBundle;
 pub use plugin::RenderPlugin;

--- a/src/render/svg3d/mod.rs
+++ b/src/render/svg3d/mod.rs
@@ -1,11 +1,9 @@
 use bevy::{
-    asset::{weak_handle, Handle},
-    ecs::{
-        component::{Component, HookContext},
-        world::DeferredWorld,
-    },
+    asset::{Handle, weak_handle},
+    ecs::{component::Component, lifecycle::HookContext, world::DeferredWorld},
+    mesh::Mesh3d,
     pbr::MeshMaterial3d,
-    render::{mesh::Mesh3d, render_resource::Shader},
+    shader::Shader,
 };
 
 mod bundle;

--- a/src/render/svg3d/plugin.rs
+++ b/src/render/svg3d/plugin.rs
@@ -1,11 +1,10 @@
+use crate::svg::Svg;
 use bevy::{
     app::{App, Plugin},
-    asset::{load_internal_asset, AssetApp},
+    asset::{AssetApp, load_internal_asset},
     pbr::{Material, MaterialPlugin},
-    render::render_resource::{Shader, ShaderRef},
+    shader::{Shader, ShaderRef},
 };
-
-use crate::svg::Svg;
 
 use super::SVG_3D_SHADER_HANDLE;
 

--- a/src/render/svg3d/plugin.rs
+++ b/src/render/svg3d/plugin.rs
@@ -1,12 +1,13 @@
+use super::SVG_3D_SHADER_HANDLE;
 use crate::svg::Svg;
 use bevy::{
     app::{App, Plugin},
     asset::{AssetApp, load_internal_asset},
-    pbr::{Material, MaterialPlugin},
+    mesh::MeshVertexBufferLayoutRef,
+    pbr::{Material, MaterialPipeline, MaterialPipelineKey, MaterialPlugin},
+    render::render_resource::{RenderPipelineDescriptor, SpecializedMeshPipelineError},
     shader::{Shader, ShaderRef},
 };
-
-use super::SVG_3D_SHADER_HANDLE;
 
 /// Plugin that renders [`Svg`](crate::svg::Svg)s in 2D
 pub struct RenderPlugin;
@@ -23,5 +24,16 @@ impl Plugin for RenderPlugin {
 impl Material for Svg {
     fn fragment_shader() -> ShaderRef {
         SVG_3D_SHADER_HANDLE.into()
+    }
+
+    fn specialize(
+        _pipeline: &MaterialPipeline,
+        descriptor: &mut RenderPipelineDescriptor,
+        _layout: &MeshVertexBufferLayoutRef,
+        _key: MaterialPipelineKey<Self>,
+    ) -> bevy::prelude::Result<(), SpecializedMeshPipelineError> {
+        descriptor.primitive.cull_mode = None;
+
+        Ok(())
     }
 }

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -1,10 +1,8 @@
 use bevy::{
+    asset::RenderAssetUsages,
     color::{Color, ColorToComponents},
-    render::{
-        mesh::{Indices, Mesh, VertexAttributeValues},
-        render_asset::RenderAssetUsages,
-        render_resource::PrimitiveTopology,
-    },
+    mesh::{Indices, Mesh, VertexAttributeValues},
+    render::render_resource::PrimitiveTopology,
 };
 use copyless::VecHelper;
 use lyon_path::math::Point;

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -3,23 +3,24 @@ use bevy::{
     color::Color,
     log::{debug, trace, warn},
     math::Vec2,
-    reflect::{std_traits::ReflectDefault, Reflect},
-    render::{mesh::Mesh, render_resource::AsBindGroup},
+    mesh::Mesh,
+    reflect::{Reflect, std_traits::ReflectDefault},
+    render::render_resource::AsBindGroup,
 };
 use copyless::VecHelper;
 use lyon_path::PathEvent;
-use lyon_tessellation::{math::Point, FillTessellator, StrokeTessellator};
+use lyon_tessellation::{FillTessellator, StrokeTessellator, math::Point};
 use std::collections::VecDeque;
 use std::iter::Peekable;
 use std::path::PathBuf;
 use std::sync::Arc;
 use svgtypes::ViewBox;
 use usvg::{
-    tiny_skia_path::{PathSegment, PathSegmentsIter},
     PaintOrder,
+    tiny_skia_path::{PathSegment, PathSegmentsIter},
 };
 
-use crate::{loader::FileSvgError, render::tessellation, Convert};
+use crate::{Convert, loader::FileSvgError, render::tessellation};
 
 /// A loaded and deserialized SVG file.
 #[derive(AsBindGroup, Reflect, Debug, Clone, Asset)]


### PR DESCRIPTION
# This PR

This PR updates bevy_svg to use Bevy 0.17 as well as fixing some deprecated usage and broken features.

## Notes

* `weak_handle` is deprecated and replaced with `uuid_handle`.
* `EventReader` is deprecated and replaced with `MessageReader`.
* The 3d `Material` implementation for `Svg` caused parts or all of some SVGs to not render in 3d mode. Disabling backface culling on the Svg material seems to have fixed this.